### PR TITLE
Fixed cross-platform build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "scripts": {
     "test": "npm run build-app && cargo run",    
-    "build-app": "rm -rf dist && rollup -c rollup.config.js",
+    "build-app": "rimraf dist && rollup -c rollup.config.js",
     "build": "npm run build-app && cargo build"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",
+    "rimraf": "^3.0.2",
     "rollup": "^2.19.0",
     "rollup-plugin-vue": "^5.1.9"
   },


### PR DESCRIPTION
Windows does not natively support `rm -rf`.
Added `rimraf`, which does the same job but on all platforms, as a development dependency and updated the script to use it.